### PR TITLE
Fix reliability with modern computers

### DIFF
--- a/omap_loader.c
+++ b/omap_loader.c
@@ -387,12 +387,10 @@ int process_args(struct arg_state * args)
     goto fail;
   }
 
-  /* Note: this is a race between the target's processor getting X-loader 
-   * running and our processor. If we fail to communicate with the X-loader, 
-   * it's possible that it hasn't been fully initialized. I'm not going to put
-   * some stupid, arbitrary sleep value here. The transfer_other_files function
-   * should be robust enough to handle some errors.
+  /* Wait a moment before attempting to communicate with X-loader. If we don't
+   * wait here, some computers end up failing to upload additional files.
    */
+  usleep(20000);
   
   /* If we are passed one file, assume that the user just wants to
      upload some initial code with no X-loader chaining

--- a/omap_loader.c
+++ b/omap_loader.c
@@ -495,6 +495,8 @@ bool omap_usb_write(libusb_device_handle * handle, unsigned char * data,
   {
     int actualWrite = 0;
     int writeAmt = sizeLeft;
+    /* Only send 512 bytes at a time. Helps with reliability sometimes. */
+    if(writeAmt > 512) { writeAmt = 512; }
 
     usleep(1000);
     ret = libusb_bulk_transfer(handle, OMAP_USB_BULK_OUT, data+iter,

--- a/omap_loader.c
+++ b/omap_loader.c
@@ -436,6 +436,7 @@ bool omap_usb_read(libusb_device_handle * handle, unsigned char * data,
     int actualRead = 0;
     int readAmt = sizeLeft;
 
+    usleep(1000);
     ret = libusb_bulk_transfer(handle, OMAP_USB_BULK_IN, data+iter,
         readAmt, &actualRead, USB_TIMEOUT);
 
@@ -491,6 +492,7 @@ bool omap_usb_write(libusb_device_handle * handle, unsigned char * data,
     int actualWrite = 0;
     int writeAmt = sizeLeft;
 
+    usleep(1000);
     ret = libusb_bulk_transfer(handle, OMAP_USB_BULK_OUT, data+iter,
         writeAmt, &actualWrite, USB_TIMEOUT);
 

--- a/omap_loader.c
+++ b/omap_loader.c
@@ -374,6 +374,12 @@ int process_args(struct arg_state * args)
     return 1;
   }
 
+  if((ret = libusb_claim_interface(dev, 0)) < 0)
+  {
+    log_error("failed to claim interface: %s\n", libusb_error_name(ret));
+    return ret;
+  }
+
   /* Communicate with the TI BootROM directly
       - retrieve ASIC ID
       - start peripheral boot


### PR DESCRIPTION
Armed with a USB sniffer as I've discussed in the comments in #1, I have improved the compatibility of this tool to the point that it works perfectly on all the Linux machines I have on hand to test with. The command I'm using to test (with an original OMAP3530 BeagleBoard) is:

`sudo ./omap_loader -p 0xd009 -f x-load.bin -f u-boot.bin -a 0x80800000 -j 0x80800000 -v`

These machines already worked with the existing code. I'm just listing the CPU they have:

- Intel Core i3-2120
- Intel Core i7-920

These machines didn't work until at least some of these patches were added. The necessary patches vary by machine.

- Intel Core i7-6700K
- Intel Core i3-7100U
- AMD Ryzen 5 3600
- AMD Ryzen 7 5700G

Detailed info about this is available in #1, but the gist of it is:

- My traces seem to indicate that the OMAP's on-chip bootloader possibly has some weird bugs where it doesn't always handle USB 2.0 high speed PING/NYET properly if you try to talk to it too fast. I don't think it's a coincidence that my older machines work fine and my newer machines don't. I saw some NAK loops and STALL errors. Add a 1 ms delay before any bulk reads/writes to avoid this.
- There seems to be some issue (possibly with the Linux XHCI driver, or the XHCI controllers themselves?) where if we try to read from X-loader too quickly after loading it into the OMAP, something gets hung up. libusb never sees X-loader's initial response, but my sniffer shows the OMAP sending it. The host controller gets hung up trying to read more (nonexistent) data from the OMAP and never reports the data back to libusb. Adding a small 20 ms delay before trying to read from X-loader fixes this.
- I also opted to do small 512-byte-at-a-time reads. It doesn't slow down performance enough to really matter, and it fixes an issue I observed where if the bus was too loaded, libusb reported a memory error. It should also even further help to avoid the PING/NYET issues I saw that the 1 ms delay fixed.
- Minor fix for a kernel warning about using an interface without claiming it

With these fixes implemented, all 6 of the machines listed above work great with omap_loader. I did run into an unrelated issue where libusb's hotplug detection is too slow on the i3-7100U. I was able to build a custom libusb without udev support to test it out (udev seems to be the bottleneck), and also I found that if I booted into a fully updated Arch install it also works fine there too.